### PR TITLE
Fix Web Interface Launch Failure from Interactive Menu

### DIFF
--- a/run.py
+++ b/run.py
@@ -39,7 +39,17 @@ def run_enhanced_desktop():
 def run_web_mode():
     """Run web interface launcher"""
     print("🌐 Starting AI Fitness Trainer Web Interface...")
-    run_script(os.path.join("web", "run_website.py"))
+
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    web_launcher = os.path.join(base_dir, "launch_web.py")
+
+    if not os.path.exists(web_launcher):
+        print(f"❌ Error: '{web_launcher}' not found.")
+        print("💡 Expected web entry file: launch_web.py at project root")
+        sys.exit(1)
+
+    subprocess.run([sys.executable, web_launcher], check=True)
+
 
 
 def run_dashboard():


### PR DESCRIPTION
## ✅ Fix Web Interface Launch Failure from Interactive Menu

### Summary
This PR fixes an issue where selecting the **Web Interface** from the interactive launcher menu failed due to an incorrect hard-coded file path. The launcher was attempting to execute a non-existent `web/run_website.py` file, causing a file-not-found error.

---

### What Was Fixed
- Updated the interactive launcher to reference the **correct web entry point**
- Replaced the incorrect path with the actual file used by the project:
  - `launch_web.py` (located at the project root)
- Improved robustness by resolving paths relative to the launcher file

---

### Root Cause
The launcher assumed a `web/` directory structure that does not exist in the repository.  
The actual web interface entry file (`launch_web.py`) resides at the project root, leading to a path mismatch and runtime failure.

---

### Changes Made
- Corrected the web launcher path in the interactive menu
- Used absolute path resolution based on `__file__` to avoid directory-dependent failures
- Added clear error messaging when the web entry file is missing

---

### How to Test
1. Run the interactive launcher:
   ```bash
   python run3.py --interactive
   ```
2. Select option `3` (Web Interface)
3. Verify that the web interface starts successfully

---
### Before 
<img width="847" height="327" alt="Screenshot2" src="https://github.com/user-attachments/assets/8a498c14-a0aa-4833-971a-e9b40d51e6ff" />

### After 
<img width="925" height="537" alt="Screenshot3" src="https://github.com/user-attachments/assets/bbb0db13-0442-4641-b933-2e2043aa69b9" />

---
### Impact
- Restores full functionality of the interactive menu
- Fixes a blocker for accessing the web interface
- Improves reliability and contributor experience
- Aligns launcher behavior with the actual project structure

---

### Related Issue
Closes #23 
