### PR TITLE
chore: remove unused imports in frontend modules (F401 cleanup)

### DIFF
--- a/frontend/streamlit_interface/app.py
+++ b/frontend/streamlit_interface/app.py
@@ -18,11 +18,9 @@ current_dir = Path(__file__).parent
 sys.path.insert(0, str(current_dir))
 
 from styles.custom_css import inject_custom_css, apply_page_config
-from styles.theme import COLORS, TYPOGRAPHY, SPACING
 from utils.icons import inject_material_icons_cdn
 from utils.state_manager import StateManager
 from services.api_client import APIClient
-from components.auth_header import render_auth_header
 
 
 def configure_page():

--- a/frontend/streamlit_interface/components/auth_header.py
+++ b/frontend/streamlit_interface/components/auth_header.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from styles.theme import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS, SHADOWS
+from styles.theme import COLORS, TYPOGRAPHY
 
 def render_auth_header():
     """

--- a/frontend/streamlit_interface/components/charts.py
+++ b/frontend/streamlit_interface/components/charts.py
@@ -5,9 +5,8 @@ This module provides reusable chart components using Plotly for data visualizati
 with consistent professional styling across the application.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 import plotly.graph_objects as go
-import plotly.express as px
 import sys
 from pathlib import Path
 

--- a/frontend/streamlit_interface/components/chatbot_dialog.py
+++ b/frontend/streamlit_interface/components/chatbot_dialog.py
@@ -4,7 +4,6 @@ Provides 24/7 fitness assistance through an interactive chat interface
 """
 
 import streamlit as st
-from datetime import datetime
 
 @st.dialog("🤖 AI Fitness Assistant - 24/7 Help", width="large")
 def chatbot_dialog():

--- a/frontend/streamlit_interface/components/hero_carousel.py
+++ b/frontend/streamlit_interface/components/hero_carousel.py
@@ -1,5 +1,4 @@
 
-import streamlit as st
 import streamlit.components.v1 as components
 
 def render_hero_carousel():

--- a/frontend/streamlit_interface/components/navigation.py
+++ b/frontend/streamlit_interface/components/navigation.py
@@ -7,7 +7,6 @@ and navigation state management using Streamlit's session_state.
 """
 
 import streamlit as st
-from typing import Optional
 import sys
 from pathlib import Path
 
@@ -16,7 +15,7 @@ parent_dir = Path(__file__).parent.parent
 if str(parent_dir) not in sys.path:
     sys.path.insert(0, str(parent_dir))
 
-from utils.icons import render_icon_with_text, get_icon_name
+from utils.icons import get_icon_name
 from styles.theme import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS, TRANSITIONS
 
 

--- a/frontend/streamlit_interface/components/top_navbar.py
+++ b/frontend/streamlit_interface/components/top_navbar.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from styles.theme import COLORS
 
 def render_top_navbar(active_page="home"):
     """

--- a/frontend/streamlit_interface/pages/1_Home.py
+++ b/frontend/streamlit_interface/pages/1_Home.py
@@ -20,7 +20,6 @@ from utils.state_manager import StateManager
 from components.navigation import Navigation
 from components.hero_carousel import render_hero_carousel
 from components.footer import render_footer
-from components.auth_header import render_auth_header
 
 
 def get_base64_image(image_path):

--- a/frontend/streamlit_interface/pages/2_Workout.py
+++ b/frontend/streamlit_interface/pages/2_Workout.py
@@ -9,10 +9,8 @@ import streamlit as st
 import sys
 from pathlib import Path
 import cv2
-import numpy as np
-from datetime import datetime, timedelta
+from datetime import datetime
 import time
-import base64
 
 
 # Add parent directory to path for imports
@@ -23,12 +21,9 @@ from styles.custom_css import inject_custom_css, apply_page_config
 from styles.theme import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS, SHADOWS
 from utils.icons import (
     inject_material_icons_cdn,
-    render_exercise_card_icon,
-    get_icon_name,
 )
 from utils.state_manager import StateManager
 from components.navigation import Navigation
-from components.auth_header import render_auth_header
 from services.api_client import APIClient, get_api_client
 from utils.error_handler import ErrorHandler
 

--- a/frontend/streamlit_interface/pages/3_History.py
+++ b/frontend/streamlit_interface/pages/3_History.py
@@ -6,7 +6,6 @@ formatted data display, and summary statistics.
 """
 
 import streamlit as st
-import textwrap
 import sys
 from pathlib import Path
 
@@ -15,15 +14,13 @@ parent_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(parent_dir))
 
 from styles.custom_css import inject_custom_css, apply_page_config
-from styles.theme import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS, SHADOWS
+from styles.theme import COLORS
 from utils.icons import (
     inject_material_icons_cdn,
     get_icon_name,
-    render_icon,
 )
 from utils.state_manager import StateManager
 from components.navigation import Navigation
-from components.auth_header import render_auth_header
 from services.workout_loader import WorkoutHistoryLoader
 from services.workout_filter import WorkoutHistoryFilter
 from services.workout_formatter import WorkoutHistoryFormatter

--- a/frontend/streamlit_interface/pages/4_Stats.py
+++ b/frontend/streamlit_interface/pages/4_Stats.py
@@ -19,12 +19,9 @@ from styles.custom_css import inject_custom_css, apply_page_config
 from styles.theme import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS, SHADOWS
 from utils.icons import (
     inject_material_icons_cdn,
-    get_icon_name,
-    render_icon,
 )
 from utils.state_manager import StateManager
 from components.navigation import Navigation
-from components.auth_header import render_auth_header
 from components.charts import ChartComponents
 from services.workout_loader import WorkoutHistoryLoader
 from services.stats_calculator import StatsCalculator

--- a/frontend/streamlit_interface/services/api_client.py
+++ b/frontend/streamlit_interface/services/api_client.py
@@ -4,7 +4,6 @@ Enhanced with error handling, retry logic, timeout configuration, and logging
 """
 import base64
 import logging
-import time
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
## Summary
Removes unused imports (F401) from Streamlit frontend modules.

## Scope
- frontend/streamlit_interface/

Only unused imports were removed.
No functional or behavioral changes.

Verified that the Streamlit application runs successfully after cleanup.