### PR TITLE
chore: remove unused imports in backend test modules (F401 cleanup)

### DIFF
--- a/backend/tests/dependencies_test.py
+++ b/backend/tests/dependencies_test.py
@@ -2,8 +2,6 @@
 Simple test for AI Fitness Trainer - Minimal dependencies
 """
 import cv2
-import sys
-import os
 
 def test_camera():
     """Test if camera works"""

--- a/backend/tests/test_edge_case_handling.py
+++ b/backend/tests/test_edge_case_handling.py
@@ -2,10 +2,9 @@
 Unit tests for edge case handling in pose quality evaluation
 Tests no pose detected, missing metrics, and invalid configuration scenarios
 """
-import pytest
 import logging
 from backend.api.pose_quality_evaluator import PoseQualityEvaluator
-from backend.api.exercise_config import get_exercise_config, ExerciseConfig, ThresholdConfig
+from backend.api.exercise_config import get_exercise_config
 
 
 class TestEdgeCaseHandling:

--- a/backend/tests/test_error_handlers.py
+++ b/backend/tests/test_error_handlers.py
@@ -3,7 +3,6 @@ Tests for global error handlers in FastAPI application
 
 Verifies that error responses follow consistent format and proper status codes.
 """
-import pytest
 from fastapi.testclient import TestClient
 from backend.api.main import app
 

--- a/backend/tests/test_exercise_analyzer.py
+++ b/backend/tests/test_exercise_analyzer.py
@@ -2,7 +2,6 @@
 Unit tests for EnhancedExerciseAnalyzer
 Tests exercise analysis and rep counting functionality
 """
-import pytest
 from backend.api.exercise_analyzer import EnhancedExerciseAnalyzer
 
 

--- a/backend/tests/test_form_metrics.py
+++ b/backend/tests/test_form_metrics.py
@@ -2,7 +2,6 @@
 Tests for form metric calculation in PoseQualityEvaluator
 Validates that calculate_form_metrics returns appropriate scores for each exercise
 """
-import pytest
 from backend.api.pose_quality_evaluator import PoseQualityEvaluator
 
 

--- a/backend/tests/test_pose_quality_evaluator.py
+++ b/backend/tests/test_pose_quality_evaluator.py
@@ -2,7 +2,6 @@
 Unit tests for PoseQualityEvaluator
 Tests quality score calculation, threshold categorization, and history tracking
 """
-import pytest
 from backend.api.pose_quality_evaluator import PoseQualityEvaluator
 
 

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -2,7 +2,6 @@
 Unit tests for SessionManager service class
 Tests session creation, retrieval, ending, and resetting functionality
 """
-import pytest
 import time
 from backend.api.session_manager import SessionManager, SessionData
 

--- a/backend/tests/test_workout_history_edge_cases.py
+++ b/backend/tests/test_workout_history_edge_cases.py
@@ -5,7 +5,6 @@ Tests Requirements: 1.3, 1.5, 2.5
 import json
 import os
 import tempfile
-import shutil
 from pathlib import Path
 import pytest
 import sys

--- a/backend/tests/test_workout_session.py
+++ b/backend/tests/test_workout_session.py
@@ -4,7 +4,6 @@ Tests session management, persistence, and data loading functionality
 """
 import pytest
 import os
-import json
 import tempfile
 import shutil
 from backend.api.workout_session import WorkoutSession


### PR DESCRIPTION
## Summary
Removes unused imports (F401) from backend test modules.

## Scope
- backend/tests/

Only unused imports were removed.
No test logic, assertions, or behavior were modified.